### PR TITLE
feat(ai-models): add opt-in TwelveLabs Pegasus caption provider

### DIFF
--- a/.changeset/twelvelabs-pegasus-captions.md
+++ b/.changeset/twelvelabs-pegasus-captions.md
@@ -1,0 +1,5 @@
+---
+"@twick/ai-models": minor
+---
+
+Add opt-in TwelveLabs Pegasus caption provider (`TwelveLabsAdapter`) that generates time-aligned captions directly from a video URL via the TwelveLabs analyze API. Registered like any other provider; defaults and existing behavior are unchanged.

--- a/packages/ai-models/.gitignore
+++ b/packages/ai-models/.gitignore
@@ -1,0 +1,1 @@
+.test-build

--- a/packages/ai-models/README.md
+++ b/packages/ai-models/README.md
@@ -56,6 +56,48 @@ This provides a provider-agnostic backend layer so Twick apps can:
 3. Keep timeline/caption/export pipeline stable while swapping models
 4. Feed normalized patch data into `@twick/workflow` for project/timeline application
 
+## Built-in providers
+
+### TwelveLabs (Pegasus captions)
+
+`TwelveLabsAdapter` is an opt-in adapter that generates time-aligned captions
+straight from a video URL using [TwelveLabs](https://twelvelabs.io) Pegasus
+video understanding — no separate transcription step. It implements the same
+`ProviderAdapter` contract and is registered like any other provider, so
+defaults and existing flows are unaffected.
+
+```ts
+import {
+  ProviderRegistry,
+  GenerationOrchestrator,
+  TwelveLabsAdapter,
+  toTimelinePatch,
+} from "@twick/ai-models";
+
+const registry = new ProviderRegistry();
+registry.registerAdapter(new TwelveLabsAdapter());
+registry.setProviderConfig({
+  provider: "twelvelabs",
+  apiKey: process.env.TWELVELABS_API_KEY,
+});
+
+const orchestrator = new GenerationOrchestrator(registry);
+
+const job = await orchestrator.createJob({
+  type: "caption",
+  provider: "twelvelabs",
+  input: { videoUrl: "https://example.com/clip.mp4", language: "en" },
+});
+
+const completed = await orchestrator.dispatch(job.id);
+const patch = toTimelinePatch(completed); // TimelineCaptionPatch
+```
+
+Captions are produced asynchronously: `startJob` creates a Pegasus analyze task
+(`POST /analyze/tasks`, `time_based_metadata` mode) and the orchestrator polls
+`getJobStatus` (`GET /analyze/tasks/{id}`) until the task is `ready`. Grab a free
+API key at [twelvelabs.io](https://twelvelabs.io) — there is a generous free tier.
+
 ## Notes
 
 - Implement `ProviderAdapter` for each production provider (e.g. Sora, HeyGen, ElevenLabs).

--- a/packages/ai-models/package.json
+++ b/packages/ai-models/package.json
@@ -20,7 +20,7 @@
     "docs": "typedoc",
     "lint": "eslint src/",
     "clean": "rimraf .turbo node_modules dist",
-    "test": "echo \"No tests for @twick/ai-models\" && exit 0"
+    "test": "tsc -p tsconfig.test.json && node --test .test-build/providers/*.test.js"
   },
   "devDependencies": {
     "@types/node": "^20.11.24",

--- a/packages/ai-models/src/index.ts
+++ b/packages/ai-models/src/index.ts
@@ -60,6 +60,8 @@ export {
   UnsupportedGenerationTypeError,
 } from "./provider-adapter";
 
+export { TwelveLabsAdapter, parseCaptionData } from "./providers/twelvelabs-adapter";
+
 export type { JobStore } from "./job-store";
 export { InMemoryJobStore } from "./job-store";
 export { GenerationOrchestrator } from "./orchestrator";

--- a/packages/ai-models/src/providers/twelvelabs-adapter.test.ts
+++ b/packages/ai-models/src/providers/twelvelabs-adapter.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { parseCaptionData } from "./twelvelabs-adapter";
+
+test("parseCaptionData converts Pegasus segments into sorted TimedTextSegments", () => {
+  const data = JSON.stringify({
+    caption: [
+      { start_time: 2.5, end_time: 4, metadata: { text: "Second line" } },
+      { start_time: 0, end_time: 2, metadata: { text: "First line" } },
+    ],
+  });
+
+  const segments = parseCaptionData(data);
+
+  assert.deepEqual(segments, [
+    { text: "First line", startMs: 0, endMs: 2000 },
+    { text: "Second line", startMs: 2500, endMs: 4000 },
+  ]);
+});
+
+test("parseCaptionData falls back to the first string metadata field", () => {
+  const data = JSON.stringify({
+    caption: [{ start_time: 0, end_time: 1, metadata: { label: "Intro" } }],
+  });
+
+  assert.deepEqual(parseCaptionData(data), [
+    { text: "Intro", startMs: 0, endMs: 1000 },
+  ]);
+});
+
+test("parseCaptionData drops empty/textless segments and tolerates bad JSON", () => {
+  assert.deepEqual(parseCaptionData("not json"), []);
+  assert.deepEqual(
+    parseCaptionData(JSON.stringify({ caption: [{ start_time: 0, end_time: 1 }] })),
+    []
+  );
+});

--- a/packages/ai-models/src/providers/twelvelabs-adapter.ts
+++ b/packages/ai-models/src/providers/twelvelabs-adapter.ts
@@ -1,0 +1,247 @@
+import type { ProviderAdapter } from "../provider-adapter";
+import type {
+  CaptionGenerationInput,
+  GenerationType,
+  ProviderConfig,
+  ProviderJobStatusResponse,
+  ProviderStartJobRequest,
+  ProviderStartJobResponse,
+  TimedTextSegment,
+} from "../orchestration-types";
+
+const DEFAULT_ENDPOINT = "https://api.twelvelabs.io/v1.3";
+const DEFAULT_MODEL = "pegasus1.5";
+const DEFAULT_SEGMENT_ID = "caption";
+
+/**
+ * Shape of a single segment returned by Pegasus when `analysis_mode` is
+ * `time_based_metadata`. Times are in seconds.
+ */
+interface TwelveLabsSegment {
+  start_time: number;
+  end_time: number;
+  metadata?: Record<string, unknown>;
+}
+
+interface CreateTaskResponse {
+  _id?: string;
+  task_id?: string;
+  status?: string;
+}
+
+interface RetrieveTaskResponse {
+  status?: string;
+  result?: { data?: string };
+  error?: { message?: string } | string;
+  message?: string;
+}
+
+/**
+ * Maps a TwelveLabs analyze-task status onto the orchestrator's status enum.
+ * TwelveLabs reports `pending` / `processing` / `ready` / `failed`.
+ */
+const mapStatus = (
+  status: string | undefined
+): ProviderJobStatusResponse["status"] => {
+  switch (status) {
+    case "ready":
+      return "completed";
+    case "failed":
+      return "failed";
+    case "processing":
+      return "running";
+    default:
+      return "pending";
+  }
+};
+
+/**
+ * Reads the caption text from a Pegasus segment's metadata. The adapter asks
+ * Pegasus for a `text` field per segment, but falls back to any string field so
+ * a slightly different prompt still yields usable captions.
+ */
+const extractText = (segment: TwelveLabsSegment): string => {
+  const meta = segment.metadata ?? {};
+  if (typeof meta.text === "string") {
+    return meta.text;
+  }
+  const firstString = Object.values(meta).find((v) => typeof v === "string");
+  return typeof firstString === "string" ? firstString : "";
+};
+
+/**
+ * Converts the raw Pegasus `result.data` payload (a JSON-encoded string keyed
+ * by segment definition id) into Twick `TimedTextSegment`s. Exported for unit
+ * testing the parsing logic without a network call.
+ */
+export const parseCaptionData = (data: string): TimedTextSegment[] => {
+  let parsed: Record<string, TwelveLabsSegment[]>;
+  try {
+    parsed = JSON.parse(data) as Record<string, TwelveLabsSegment[]>;
+  } catch {
+    return [];
+  }
+
+  const segments = Object.values(parsed).flat();
+  return segments
+    .filter((s): s is TwelveLabsSegment => s != null && typeof s === "object")
+    .map((s) => ({
+      text: extractText(s),
+      startMs: Math.max(0, Math.round((s.start_time ?? 0) * 1000)),
+      endMs: Math.round((s.end_time ?? s.start_time ?? 0) * 1000),
+    }))
+    .filter((s) => s.text.length > 0)
+    .sort((a, b) => a.startMs - b.startMs);
+};
+
+/**
+ * Opt-in provider adapter that uses TwelveLabs Pegasus video understanding to
+ * generate time-aligned captions directly from a video URL — no separate
+ * transcription step required.
+ *
+ * Register it the same way as any other provider:
+ *
+ * ```ts
+ * const registry = new ProviderRegistry();
+ * registry.registerAdapter(new TwelveLabsAdapter());
+ * registry.setProviderConfig({
+ *   provider: "twelvelabs",
+ *   apiKey: process.env.TWELVELABS_API_KEY,
+ * });
+ * ```
+ *
+ * Captions are produced asynchronously: `startJob` creates a Pegasus analyze
+ * task and returns its id; the orchestrator polls `getJobStatus` until the task
+ * is `ready`.
+ */
+export class TwelveLabsAdapter implements ProviderAdapter {
+  readonly provider = "twelvelabs" as const;
+  readonly supportedTypes: readonly GenerationType[] = ["caption"];
+
+  async startJob(
+    request: ProviderStartJobRequest,
+    config: ProviderConfig
+  ): Promise<ProviderStartJobResponse> {
+    const input = request.input as CaptionGenerationInput;
+    if (!input?.videoUrl) {
+      throw new Error("TwelveLabs caption generation requires input.videoUrl");
+    }
+
+    const promptHint = input.language
+      ? ` Write the caption text in ${input.language}.`
+      : "";
+
+    const body = {
+      model_name: config.modelMap?.[request.type] ?? DEFAULT_MODEL,
+      video: { type: "url", url: input.videoUrl },
+      analysis_mode: "time_based_metadata",
+      response_format: {
+        type: "segment_definitions",
+        segment_definitions: [
+          {
+            id: DEFAULT_SEGMENT_ID,
+            description:
+              "Spoken-line and on-screen-action captions for subtitles.",
+            fields: [
+              {
+                name: "text",
+                type: "string",
+                description:
+                  "A short caption describing what is said or happening." +
+                  promptHint,
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const response = await this.fetchJson<CreateTaskResponse>(
+      `${this.baseUrl(config)}/analyze/tasks`,
+      config,
+      { method: "POST", body: JSON.stringify(body) }
+    );
+
+    const providerJobId = response.task_id ?? response._id;
+    if (!providerJobId) {
+      throw new Error("TwelveLabs did not return a task id");
+    }
+
+    return { providerJobId, status: mapStatus(response.status) };
+  }
+
+  async getJobStatus(
+    providerJobId: string,
+    config: ProviderConfig
+  ): Promise<ProviderJobStatusResponse> {
+    const response = await this.fetchJson<RetrieveTaskResponse>(
+      `${this.baseUrl(config)}/analyze/tasks/${encodeURIComponent(
+        providerJobId
+      )}`,
+      config,
+      { method: "GET" }
+    );
+
+    const status = mapStatus(response.status);
+    if (status === "completed") {
+      const captions = parseCaptionData(response.result?.data ?? "");
+      return { status, output: { captions } };
+    }
+    if (status === "failed") {
+      const error =
+        typeof response.error === "string"
+          ? response.error
+          : response.error?.message ?? response.message ?? "Analysis failed";
+      return { status, error };
+    }
+    return { status };
+  }
+
+  private baseUrl(config: ProviderConfig): string {
+    return (config.endpoint ?? DEFAULT_ENDPOINT).replace(/\/+$/, "");
+  }
+
+  private async fetchJson<T>(
+    url: string,
+    config: ProviderConfig,
+    init: RequestInit
+  ): Promise<T> {
+    const apiKey = config.apiKey;
+    if (!apiKey) {
+      throw new Error("TwelveLabs provider config requires an apiKey");
+    }
+
+    const controller =
+      config.timeoutMs != null ? new AbortController() : undefined;
+    const timer = controller
+      ? setTimeout(() => controller.abort(), config.timeoutMs)
+      : undefined;
+
+    try {
+      const response = await fetch(url, {
+        ...init,
+        signal: controller?.signal,
+        headers: {
+          "x-api-key": apiKey,
+          "Content-Type": "application/json",
+        },
+      });
+
+      const text = await response.text();
+      const json = text ? (JSON.parse(text) as T) : ({} as T);
+
+      if (!response.ok) {
+        const message =
+          (json as { message?: string }).message ??
+          `TwelveLabs request failed with ${response.status}`;
+        throw new Error(message);
+      }
+
+      return json;
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
+  }
+}

--- a/packages/ai-models/src/types.ts
+++ b/packages/ai-models/src/types.ts
@@ -16,6 +16,7 @@ export type AIModelProvider =
   | "openai"
   | "gemini"
   | "bedrock"
+  | "twelvelabs"
   | "local";
 
 export interface ModelDimension {

--- a/packages/ai-models/tsconfig.json
+++ b/packages/ai-models/tsconfig.json
@@ -18,6 +18,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "src/**/*.test.ts"],
   "include": ["src/**/*"]
 }

--- a/packages/ai-models/tsconfig.test.json
+++ b/packages/ai-models/tsconfig.test.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": false,
+    "declarationMap": false,
+    "outDir": ".test-build",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "verbatimModuleSyntax": false
+  },
+  "exclude": ["node_modules"],
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## What this adds

An opt-in `TwelveLabsAdapter` in `@twick/ai-models` that generates **time-aligned captions directly from a video URL** using [TwelveLabs](https://twelvelabs.io) Pegasus video understanding — no separate transcription step. It implements the existing `ProviderAdapter` contract (the package README already invites provider implementations like Sora/HeyGen/ElevenLabs), so it slots into `ProviderRegistry` / `GenerationOrchestrator` exactly like any other provider and emits the standard `TimelineCaptionPatch`.

```ts
import { ProviderRegistry, GenerationOrchestrator, TwelveLabsAdapter } from "@twick/ai-models";

const registry = new ProviderRegistry();
registry.registerAdapter(new TwelveLabsAdapter());
registry.setProviderConfig({ provider: "twelvelabs", apiKey: process.env.TWELVELABS_API_KEY });

const job = await new GenerationOrchestrator(registry).createJob({
  type: "caption",
  provider: "twelvelabs",
  input: { videoUrl: "https://example.com/clip.mp4", language: "en" },
});
```

Under the hood it creates a Pegasus analyze task (`POST /analyze/tasks`, `time_based_metadata` mode) on `startJob`, and the orchestrator polls `getJobStatus` (`GET /analyze/tasks/{id}`) until the task is `ready`, then maps each segment to a `TimedTextSegment`.

## Why it helps this project

Captioning is a core editor workflow. Pegasus produces semantically-aware, time-aligned captions straight from a video URL, giving Twick apps an AI caption option behind the same provider-agnostic seam — and the orchestrator's built-in fallback means it can sit alongside other providers without lock-in.

## Opt-in / non-breaking

- Adds `"twelvelabs"` to the `AIModelProvider` union and a new `src/providers/twelvelabs-adapter.ts`; touches no existing provider, default, or runtime path.
- No new runtime dependencies — uses native `fetch` (Node 20+), consistent with the rest of the repo.

## How it was tested

- **No-network unit test** (`twelvelabs-adapter.test.ts`, `node:test`, zero new deps) covering caption parsing, metadata fallback, and malformed input — passing (3/3).
- `pnpm --filter @twick/ai-models build` (tsc typecheck + vite lib build + dts rollup) — passing.
- **Live end-to-end against the real API:** created a real Pegasus analyze task and polled it to `ready`. The returned `result.data` (`{"caption":[{"start_time":0,"end_time":10,"metadata":{"text":"..."}}]}`) parses correctly into `{ text, startMs: 0, endMs: 10000 }`. Auth, both routes, request payload, and status transitions (`queued → processing → ready`) all verified.

A changeset (`minor` for `@twick/ai-models`) is included.

Per CONTRIBUTING, significant changes are encouraged to start with an issue — happy to open one or adjust the approach (segmentation prompt, sync vs async, etc.) to match maintainer preferences. You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
